### PR TITLE
Make SglPPow package suggested for SmallGrp

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -118,7 +118,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.9",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
-  SuggestedOtherPackages := [ ],
+  SuggestedOtherPackages := [ [ "SglPPow", ">= 2.0" ] ],
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
Closes #11.

Will also cause loading LiePRing(>=1.8), LieRing(>=2.2), which are suggested for SglPPow.