### PR TITLE
Change capitalisation in the name: smallgrp -> SmallGrp

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -1,5 +1,5 @@
 #
-# smallgrp: The GAP Small Groups Library
+# SmallGrp: The GAP Small Groups Library
 #
 # This file contains package meta data. For additional information on
 # the meaning and correct usage of these fields, please consult the
@@ -8,7 +8,7 @@
 #
 SetPackageInfo( rec(
 
-PackageName := "smallgrp",
+PackageName := "SmallGrp",
 Subtitle := "The GAP Small Groups Library",
 Version := "1.2",
 Date := "02/10/2017", # dd/mm/yyyy format
@@ -104,7 +104,11 @@ ArchiveFormats := ".tar.gz",
 ##
 Status := "dev",
 
-AbstractHTML   :=  "",
+AbstractHTML   :=  "The <span class=\"smallgrp\">SmallGrp</span> package \
+provides the library of groups of certain "small" orders. The groups are \
+sorted by their orders and they are listed up to isomorphism; that is, for \
+each of the available orders a complete and irredundant list of isomorphism \
+type representatives of groups is given.",
 
 PackageDoc := rec(
   BookName  := "smallgrp",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/gap-packages/smallgrp.svg?branch=master)](https://travis-ci.org/gap-packages/smallgrp)
 [![Code Coverage](https://codecov.io/github/gap-packages/smallgrp/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/smallgrp)
 
-# The smallgrp GAP package
+# The SmallGrp GAP package
 
 
 

--- a/doc/smallgrp.xml
+++ b/doc/smallgrp.xml
@@ -4,7 +4,7 @@
 <!DOCTYPE Book SYSTEM "gapdoc.dtd"
 [
 <!ENTITY see '<Alt Only="LaTeX">$	o$</Alt><Alt Not="LaTeX">--&gt;</Alt>'>
-<!ENTITY smallgrp '<Package>smallgrp</Package>'>
+<!ENTITY smallgrp '<Package>SmallGrp</Package>'>
 ]
 >
 <Book Name="smallgrp">

--- a/init.g
+++ b/init.g
@@ -1,5 +1,5 @@
 #
-# smallgrp: The GAP Small Groups Library
+# SmallGrp: The GAP Small Groups Library
 #
 # Reading the declaration part of the package.
 #

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,5 +1,5 @@
 #
-# smallgrp: The GAP Small Groups Library
+# SmallGrp: The GAP Small Groups Library
 #
 # This file is a script which compiles the package manual.
 #

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,5 +1,5 @@
 #
-# smallgrp: The GAP Small Groups Library
+# SmallGrp: The GAP Small Groups Library
 #
 # This file runs package tests. It is also referenced in the package
 # metadata in PackageInfo.g.


### PR DESCRIPTION
This closes #21. Similar change for TransGrp merged in https://github.com/hulpke/transgrp/pull/25, and PrimGrp already had name in the same style.

