### PR TITLE
Clarify package license

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,3 +1,4 @@
 The SmallGroups Library is copyright by Hans Ulrich Besche, Bettina Eick and
-Eamonn O'Brien in 2007. You are free to distribute the SmallGroups Library,
-provided that you make no modifications nor remove this copyright notice.
+Eamonn O'Brien in 2007, and is licensed under the Artistic License 2.0.
+For details, please refer to the LICENSE file.
+

--- a/README
+++ b/README
@@ -13,9 +13,9 @@
 #
 #############################################################################
 
-The SmallGroups Library is copyright by Hans Ulrich Besche, Bettina Eick and 
-Eamonn O'Brien in 2007. You are free to distribute the SmallGroups Library, 
-provided that you make no modifications nor remove this copyright notice.
+The SmallGroups Library is copyright by Hans Ulrich Besche, Bettina Eick and
+Eamonn O'Brien in 2007, and is licensed under the Artistic License 2.0.
+For details, please refer to the LICENSE file.
 
 #############################################################################
 #

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Please submit bug reports and feature requests via our GitHub issue tracker:
 The Small Groups Library is free software distributed under
 the [Artistic License 2.0](https://opensource.org/licenses/Artistic-2.0).
 
-For details see the files LICENSE and COPYRIGHT.
+For details see the files `LICENSE` and `COPYRIGHT.md`.


### PR DESCRIPTION
Specifically, update the copyright statements in COPYRIGHT.md and README to mention the Artistic License 2.0

Resolves #31 

Ideally, this should be put in a release of this package to be included with the final version of GAP 4.9