### PR TITLE
AllSmallGroups is documented in this book, not in the GAP ref manual.

### DIFF
--- a/gap/small.gd
+++ b/gap/small.gd
@@ -177,7 +177,7 @@ UnbindGlobal( "OneGroup" );
 ##  <Description>
 ##  returns one group with certain properties as specified by <A>arg</A>.
 ##  The permitted arguments are those supported by
-##  <Ref BookName="ref" Func="AllSmallGroups"/>.
+##  <Ref Func="AllSmallGroups"/>.
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>


### PR DESCRIPTION
This fixes a broken reference when building the documentation with GAP 4.10.0.