### PR TITLE
Fix type of SMALL_GROUPS_OLD_ORDER reference.

### DIFF
--- a/doc/overview.xml
+++ b/doc/overview.xml
@@ -141,7 +141,7 @@ Magma, Version 2.23. In earlier releases of this library, the arrangement in
 orders <M>p^7</M>, <M>p=3,5,7,11</M> disagreed. An attempt to fix this was
 instated on version 1.1 of this library, but a wrong permutation was used. If
 you would like to refer to index numbers for these orders in older versions of
-the library, see <Ref Sect="SMALL_GROUPS_OLD_ORDER"/>). The arrangement of
+the library, see <Ref Var="SMALL_GROUPS_OLD_ORDER"/>). The arrangement of
 all other orders has always agreed and has remained stable.
 </Section>
 


### PR DESCRIPTION
Building the documentation reveals the problem:
```
#I Constructing LaTeX version and calling pdflatex:
#I Writing LaTeX file, 4 x pdflatex with bibtex and makeindex, 
#W There were LaTeX Warnings:
LaTeX Warning: Reference `SMALL_GROUPS_OLD_ORDER' on page 4 undefined on input\
 
line 240.

____________________
LaTeX Warning: There were undefined references.

Package atveryend Info: Empty hook `AtVeryVeryEnd' on input line 570.
____________________

#I Writing manual.six file ... 
```