### PR TITLE
FIX: Use correct numbering in selector function

### DIFF
--- a/small3/smlgp3.g
+++ b/small3/smlgp3.g
@@ -351,7 +351,7 @@ end;
 ##                  
 SELECT_SMALL_GROUPS_FUNCS[ 11 ] := function( size, funcs, vals, inforec, all,
                                              id, idList)
-    local result, i, g, ok, j, range;
+    local result, i, g, ok, j, range, nid;
 
     if not IsBound( inforec.number ) then
         inforec := NUMBER_SMALL_GROUPS_FUNCS[ inforec.func ]( size, inforec);
@@ -368,7 +368,20 @@ SELECT_SMALL_GROUPS_FUNCS[ 11 ] := function( size, funcs, vals, inforec, all,
         range := idList;
     fi;
     for i in range do                         
-        g := SMALL_GROUP_FUNCS[ inforec.func ]( size, i, inforec );
+        nid:=i;
+        if not SMALL_GROUPS_OLD_ORDER then
+            if size = 3^7 then
+                nid := SMALLGP_PERM3(i);
+            elif size = 5^7 then
+                nid := SMALLGP_PERM5(i);
+            elif size = 7^7 then
+                nid := SMALLGP_PERM7(i);
+            elif size = 11^7 then
+                nid := SMALLGP_PERM11(i);
+            fi;
+        fi;
+
+        g := SMALL_GROUP_FUNCS[ inforec.func ]( size, nid, inforec );
         SetIdGroup( g, [ size, i ] );
         ok := true;
         for j in [ 1 .. Length( funcs ) ] do

--- a/tst/ordering.tst
+++ b/tst/ordering.tst
@@ -9,6 +9,10 @@ gap> Order(PermList(List([1..NrSmallGroups(7^7)],SMALLGP_PERM7)));
 19308644774268106374
 gap> Order(PermList(List([1..NrSmallGroups(11^7)],SMALLGP_PERM11)));
 4900488315903285563137680
+gap> G := SmallGroup(5^7,656);;
+gap> H := OneSmallGroup(Size,5^7,G->IdGroup(G)[2],656);;
+gap> GapInputPcGroup(G,"G")=GapInputPcGroup(H,"G");
+true
 
 #
 gap> STOP_TEST("ordering,tst");;


### PR DESCRIPTION
When the concept of renumbering was implemented in version 1.2, it was forgotten (Not the only mistake. The renumbering also was wrong) to also apply the same permutation to the `One/AllSmallGroups` selector functions. This PR does so. It might be preferrable not to change the global selector function, but only the one in slot 26 (to which this one from slot 11 is copied). I leave that to the maintainers.