### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/tst/small-7-8-9.tst
+++ b/tst/small-7-8-9.tst
@@ -136,13 +136,13 @@ gap> AllSmallGroups(Size, type20, IsAbelian, true);
   <pc group of size 371293 with 5 generators>, 
   <pc group of size 371293 with 5 generators> ]
 
-#
+# We avoid viewing the cyclic groups to avoid the grammatically incorrect output
+# '1 generators' given by older versions of GAP
 gap> type21 := [15625, 117649];;
 gap> List(type21, NrSmallGroups);
 [ 684, 860 ]
-gap> AllSmallGroups(Size, type21, IsAbelian);
-[ <pc group of size 15625 with 1 generators>, 
-  <pc group of size 15625 with 2 generators>, 
+gap> AllSmallGroups(Size, type21, x -> IsAbelian(x) and not IsCyclic(x));
+[ <pc group of size 15625 with 2 generators>, 
   <pc group of size 15625 with 2 generators>, 
   <pc group of size 15625 with 3 generators>, 
   <pc group of size 15625 with 2 generators>, 
@@ -152,7 +152,6 @@ gap> AllSmallGroups(Size, type21, IsAbelian);
   <pc group of size 15625 with 4 generators>, 
   <pc group of size 15625 with 5 generators>, 
   <pc group of size 15625 with 6 generators>, 
-  <pc group of size 117649 with 1 generators>, 
   <pc group of size 117649 with 2 generators>, 
   <pc group of size 117649 with 2 generators>, 
   <pc group of size 117649 with 3 generators>, 

--- a/tst/small.tst
+++ b/tst/small.tst
@@ -143,12 +143,14 @@ Error, usage: AllSmallGroups / OneGroup(
              function2, [ values2 ], ... )
 gap> OneSmallGroup(128);
 <pc group of size 128 with 7 generators>
-gap> OneSmallGroup(Size, 3);
-<pc group of size 3 with 1 generators>
+gap> G := OneSmallGroup(Size, 3);;
+gap> Size(G) = 3 and Length(GeneratorsOfGroup(G)) = 1;
+true
 gap> OneSmallGroup(Size, [4, 5]);
 <pc group of size 4 with 2 generators>
-gap> OneSmallGroup(2, 3);
-<pc group of size 2 with 1 generators>
+gap> G := OneSmallGroup(2, 3);;
+gap> Size(G) = 2 and Length(GeneratorsOfGroup(G)) = 1;
+true
 gap> OneSmallGroup(2, Size);
 fail
 gap> StructureDescription(OneSmallGroup(4, [1]));
@@ -302,8 +304,7 @@ gap> FrattinifactorSize(CyclicGroup(IsPermGroup, 2));
 2
 gap> FrattinifactorId(CyclicGroup(IsPermGroup, 2));
 [ 2, 1 ]
-gap> C2 := CyclicGroup(2);
-<pc group of size 2 with 1 generators>
+gap> C2 := CyclicGroup(2);;
 gap> H := DirectProduct(C2, C2, C2, C2, C2, C2, C2, C2, C2);
 <pc group of size 512 with 9 generators>
 gap> StructureDescription(H);

--- a/tst/smlgp1.tst
+++ b/tst/smlgp1.tst
@@ -216,7 +216,8 @@ true
 gap> IsIdenticalObj(SELECT_SMALL_GROUPS_FUNCS[7], f);
 true
 
-#
+# We avoid viewing cyclic groups to avoid the grammatically incorrect output
+# '1 generators' given by older versions of GAP
 gap> SELECT_SMALL_GROUPS_FUNCS[1](7, [IsCyclic], [[true]],
 > SMALL_AVAILABLE_FUNCS[1](7), true, true, fail);
 [ [ 7, 1 ] ]
@@ -229,12 +230,14 @@ fail
 gap> SELECT_SMALL_GROUPS_FUNCS[1](7, [Size], [[7]],
 > SMALL_AVAILABLE_FUNCS[1](7), true, true, [1]);
 [ [ 7, 1 ] ]
-gap> SELECT_SMALL_GROUPS_FUNCS[1](7, [Size], [[7]],
-> SMALL_AVAILABLE_FUNCS[1](7), true, false, [1]);
-[ <pc group of size 7 with 1 generators> ]
-gap> SELECT_SMALL_GROUPS_FUNCS[1](7, [Size], [[7]],
-> SMALL_AVAILABLE_FUNCS[1](7), false, false, [1]);
-<pc group of size 7 with 1 generators>
+gap> x := SELECT_SMALL_GROUPS_FUNCS[1](7, [Size], [[7]],
+> SMALL_AVAILABLE_FUNCS[1](7), true, false, [1]);;
+gap> Length(x) = 1 and Size(x[1]) = 7 and Length(GeneratorsOfGroup(x[1])) = 1;
+true
+gap> x := SELECT_SMALL_GROUPS_FUNCS[1](7, [Size], [[7]],
+> SMALL_AVAILABLE_FUNCS[1](7), false, false, [1]);;
+gap> Size(x) = 7 and Length(GeneratorsOfGroup(x)) = 1;
+true
 gap> SELECT_SMALL_GROUPS_FUNCS[5](45, [IsCyclic], [[true]],
 > SMALL_AVAILABLE_FUNCS[1](45), false, false, fail);
 <pc group of size 45 with 3 generators>


### PR DESCRIPTION
In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` for `CyclicGroup(3);` will change from `<pc group of size 3 with 1 generators>` to `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards and forwards compatibility of this package with GAP.

See gap-system/gap#3992 and gap-system/gap#4050 for more context.