### PR TITLE
Name the functions shared between layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ This file describes changes in the smallgrp package.
 
 # 1.6dev
 
+  - Require GAP 4.12
   - Selection by `IsAbelian`, `IsNilpotentGroup`, `IsSupersolvableGroup`,
     `IsSolvableGroup`, `RankPGroup` and `PClassPGroup` now avoids
     constructing the groups for most orders which had no precomputed data,

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -117,7 +117,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.9",
+  GAP := ">= 4.12",
   NeededOtherPackages := [ ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],

--- a/gap/small.gi
+++ b/gap/small.gi
@@ -501,6 +501,80 @@ end;
 
 #############################################################################
 ##
+#F  SMALL_GROUPS_SELECT_GENERIC( size, funcs, vals, inforec, all, id, idList )
+##
+##  the selection for a layer with no better way: narrow the candidates with
+##  what 'SMALL_GROUPS_PROPERTY_IDS' knows, then construct the rest and test
+##  them.
+SMALL_GROUPS_SELECT_GENERIC := function( size, funcs, vals, inforec,
+                                        all, id, idList )
+    local result, i, g, ok, j, sel, range, nid;
+
+    if not IsBound( inforec.number ) then
+        inforec := NUMBER_SMALL_GROUPS_FUNCS[ inforec.func ]( size, inforec);
+    fi;
+
+    # narrow down the candidates using properties which can be decided from
+    # the position of a group in the library
+    sel   := SMALL_GROUPS_PROPERTY_IDS( size, inforec, funcs, vals );
+    funcs := sel.funcs;
+    vals  := sel.vals;
+
+    if idList = fail then
+        range := SMALL_IDS_EXPAND( sel.ids );
+    else
+        range := Filtered( idList, x -> SMALL_IDS_MEMBER( sel.ids, x ) );
+    fi;
+
+    # if nothing is left to be checked, the groups need not be constructed
+    if funcs = [ ] and all and id then
+        return List( range, x -> [ size, x ] );
+    fi;
+
+    if funcs <> [ ] and idList = fail then
+        Info( InfoWarning, 2, "`SelectSmallGroups' checks ", Length( range ),
+                            " grps of size ", size, " with trivial methods");
+    fi;
+
+    result := [ ];
+    for i in range do
+        nid:=i;
+        if not SMALL_GROUPS_OLD_ORDER then
+            if size = 3^7 then
+                nid := SMALLGP_PERM3(i);
+            elif size = 5^7 then
+                nid := SMALLGP_PERM5(i);
+            elif size = 7^7 then
+                nid := SMALLGP_PERM7(i);
+            elif size = 11^7 then
+                nid := SMALLGP_PERM11(i);
+            fi;
+        fi;
+
+        g := SMALL_GROUP_FUNCS[ inforec.func ]( size, nid, inforec );
+        SetIdGroup( g, [ size, i ] );
+        ok := true;
+        for j in [ 1 .. Length( funcs ) ] do
+            ok := ok and funcs[ j ]( g ) in vals[ j ];
+        od;
+        if all and id and ok then
+            Add( result, [ size, i ] );
+        elif all and ok then
+            Add( result, g );
+        elif ok then          
+            return g;                                           
+        fi;
+    od;                                                                     
+
+    if all then
+        return result;
+    else
+        return fail;
+    fi;
+end;
+
+#############################################################################
+##
 #V  SMALL_GROUP_LIB
 ##
 ##  This list will contain all data for the group construction read from the

--- a/id10/idgrp10.g
+++ b/id10/idgrp10.g
@@ -138,7 +138,7 @@ ID_GROUP_FUNCS[ 25 ] := function( G, inforec )
             if not IsBound( ID_GROUP_TREE.next[ Size( G ) ] ) then
                 ReadSmallLib( "ids", 10, Int( Size(G) / 500 ) + 1, [] );
             fi;
-            return i + 1 + ID_GROUP_FUNCS[ 8 ]( G, rec( lib := 10 ) );
+            return i + 1 + ID_GROUP_BY_TREE( G, rec( lib := 10 ) );
         fi;
     od;
 end;

--- a/id2/idgrp2.g
+++ b/id2/idgrp2.g
@@ -22,7 +22,7 @@ end;
 
 #############################################################################
 ##
-#F  ID_GROUP_FUNCS[ 8 ]( G, inforec, <fpcache>, <lookup> )
+#F  ID_GROUP_BY_TREE( G, inforec, <fpcache>, <lookup> )
 ##
 ##  standard lookup in identification tree
 ##
@@ -31,7 +31,7 @@ end;
 ##  if lookup is set, just the information if the specified branch exists is
 ##  returned (used to investigate if some situaations are unique in small3)
 ##
-ID_GROUP_FUNCS[ 8 ] := function( arg )
+ID_GROUP_BY_TREE := function( arg )
     local level, branch, indices, fp, l, L, i, j, size,
           coc, desc, adesc, pos, filename, ldesc, Pack, sfp, newcls, lookup,
           cfp, classes, classtyps, sclasstyps, asList, G, inforec, fpcache;              
@@ -218,6 +218,8 @@ ID_GROUP_FUNCS[ 8 ] := function( arg )
     # branch is now a integer
     return branch;
 end;
+
+ID_GROUP_FUNCS[ 8 ] := ID_GROUP_BY_TREE;
 
 #############################################################################
 ##

--- a/id3/idgrp3.g
+++ b/id3/idgrp3.g
@@ -62,7 +62,7 @@ ID_GROUP_FUNCS[ 13 ] := function( G, inforec )
         if size = 768 and not IsBound( ID_GROUP_TREE.next[ 768 ] ) then
             ID_GROUP_TREE.next[ 768 ] := rec( fp:= [ 1, 2 ], next:= [ ] );
         fi;
-        return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ size, 2 ] );
+        return ID_GROUP_BY_TREE( G, inforec, [ size, 2 ] );
     fi;
 
     sid := IdGroup( SylowSubgroup( G, 2 ) )[ 2 ];
@@ -84,7 +84,7 @@ ID_GROUP_FUNCS[ 13 ] := function( G, inforec )
         if size = 768 and not IsBound( ID_GROUP_TREE.next[ 768 ] ) then
             ID_GROUP_TREE.next[ 768 ] := rec( fp:= [ 1, 2 ], next:= [ ] );
         fi;
-        return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ size, 1, sid ] );
+        return ID_GROUP_BY_TREE( G, inforec, [ size, 1, sid ] );
     fi;
 
     # p-sylow-subgroup is normal
@@ -188,10 +188,10 @@ ID_GROUP_FUNCS[ 13 ] := function( G, inforec )
     if IsBound( c[ n ][ typ ] ) then
         c := c[ n ][ typ ];
         if c > 1 then
-            i := ID_GROUP_FUNCS[ 8 ]( G, inforec,
+            i := ID_GROUP_BY_TREE( G, inforec,
                                      [ n, typ, sid mod c, sid, cid ], true );
         else
-            i := ID_GROUP_FUNCS[ 8 ]( G, inforec,
+            i := ID_GROUP_BY_TREE( G, inforec,
                                      [ n, typ, sid, cid ], true );
         fi;
         p := [ 3, 5, 17, 17, 97 ];
@@ -222,10 +222,10 @@ ID_GROUP_FUNCS[ 13 ] := function( G, inforec )
                 fi;
             fi;
             if c > 1 then
-                return ID_GROUP_FUNCS[ 8 ]( G, inforec,
+                return ID_GROUP_BY_TREE( G, inforec,
                                            [ n, typ, sid mod c, sid, cid ] );
             else
-                return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ n, typ, sid,cid] );
+                return ID_GROUP_BY_TREE( G, inforec, [ n, typ, sid,cid] );
             fi;
         fi;
     fi;

--- a/id4/idgrp4.g
+++ b/id4/idgrp4.g
@@ -47,7 +47,7 @@ ID_GROUP_FUNCS[ 17 ] := function( G, inforec )
         if size = 1053 then
             return 51;
         fi;
-        return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ size, 2 ] );
+        return ID_GROUP_BY_TREE( G, inforec, [ size, 2 ] );
     fi;
 
     sid := IdGroup( SylowSubgroup( G, inforec.q ) )[ 2 ];
@@ -64,7 +64,7 @@ ID_GROUP_FUNCS[ 17 ] := function( G, inforec )
            or ( SMALL_GROUP_LIB[ size ].pnil.syl[ pos + 1 ] <> sid ) then
             return num + pos;
         fi;
-        return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ size, 1, sid ] );
+        return ID_GROUP_BY_TREE( G, inforec, [ size, 1, sid ] );
     fi;
 
     # p-sylow-subgroup is normal
@@ -122,10 +122,10 @@ ID_GROUP_FUNCS[ 17 ] := function( G, inforec )
     if IsBound( c[ n ][ typ ] ) then
         c := c[ n ][ typ ];
         if c > 1 then
-            i := ID_GROUP_FUNCS[ 8 ]( G, inforec,
+            i := ID_GROUP_BY_TREE( G, inforec,
                                     [ nn, typ, sid mod c, sid, cid ], true );
         else
-            i := ID_GROUP_FUNCS[ 8 ]( G, inforec,
+            i := ID_GROUP_BY_TREE( G, inforec,
                                     [ nn, typ, sid, cid ], true );
         fi;
         p := [ ,, [ 7, 19, 109, 163 ],, [ 11, 101, 251 ],, [29, 197 ] ];

--- a/id6/idgrp6.g
+++ b/id6/idgrp6.g
@@ -46,9 +46,9 @@ ID_GROUP_FUNCS[ 15 ] := function( G, inforec )
 
     if IsSolvable( G ) and IsNormal( G, HallSubgroup( G, [ 3, 5 ] ) ) then
         sid := IdGroup( SylowSubgroup( G, 2 ) )[ 2 ];
-        return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ Size( G ), 1, 
+        return ID_GROUP_BY_TREE( G, inforec, [ Size( G ), 1, 
                ( sid - 1 ) mod 500 + 1, sid ] );
     fi;
 
-    return ID_GROUP_FUNCS[ 8 ]( G, inforec, [ Size( G ), 2 ] );
+    return ID_GROUP_BY_TREE( G, inforec, [ Size( G ), 2 ] );
 end;

--- a/small10/smlgp10.g
+++ b/small10/smlgp10.g
@@ -191,8 +191,8 @@ end;
 ##
 #F SELECT_SMALL_GROUPS_FUNCS[ 24 .. 25 ]( funcs, vals, inforec, all, id )
 ##
-SELECT_SMALL_GROUPS_FUNCS[ 24 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
-SELECT_SMALL_GROUPS_FUNCS[ 25 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
+SELECT_SMALL_GROUPS_FUNCS[ 24 ] := SMALL_GROUPS_SELECT_GENERIC;
+SELECT_SMALL_GROUPS_FUNCS[ 25 ] := SMALL_GROUPS_SELECT_GENERIC;
 
 #############################################################################
 ##

--- a/small11/smlgp11.g
+++ b/small11/smlgp11.g
@@ -227,7 +227,7 @@ end;
 ##
 #F SELECT_SMALL_GROUPS_FUNCS[ 26 ]( funcs, vals, inforec, all, id )
 ##
-SELECT_SMALL_GROUPS_FUNCS[ 26 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
+SELECT_SMALL_GROUPS_FUNCS[ 26 ] := SMALL_GROUPS_SELECT_GENERIC;
 
 #############################################################################
 ##

--- a/small2/smlgp2.g
+++ b/small2/smlgp2.g
@@ -45,11 +45,11 @@ end;
 
 #############################################################################
 ##
-#F  CODE_SMALL_GROUP_FUNCS[ 8 .. 9 ]( size, i, inforec )
+#F  CODE_SMALL_GROUP_FROM_LIB( size, i, inforec )
 ##
 ##  fetches the code of the group [ size, i ] from the library data and 
 ##  loads the data if necessary
-CODE_SMALL_GROUP_FUNCS[ 8 ] := function( size, i, inforec )
+CODE_SMALL_GROUP_FROM_LIB := function( size, i, inforec )
     local g;
 
     if not IsBound( SMALL_GROUP_LIB[ size ] ) then
@@ -67,7 +67,8 @@ CODE_SMALL_GROUP_FUNCS[ 8 ] := function( size, i, inforec )
 
     return SMALL_GROUP_LIB[ size ][ i ];
 end;
-CODE_SMALL_GROUP_FUNCS[ 9 ] := CODE_SMALL_GROUP_FUNCS[ 8 ];
+CODE_SMALL_GROUP_FUNCS[ 8 ] := CODE_SMALL_GROUP_FROM_LIB;
+CODE_SMALL_GROUP_FUNCS[ 9 ] := CODE_SMALL_GROUP_FROM_LIB;
 
 #############################################################################
 ##

--- a/small3/smlgp3.g
+++ b/small3/smlgp3.g
@@ -346,75 +346,10 @@ NUMBER_SMALL_GROUPS_FUNCS[ 11 ] := function( size, inforec )
 end;
 
 #############################################################################
-##                          
-#F SELECT_SMALL_GROUPS_FUNCS[ 11 ]( funcs, vals, inforec, all, id, idList )
-##                  
-SELECT_SMALL_GROUPS_FUNCS[ 11 ] := function( size, funcs, vals, inforec, all,
-                                             id, idList)
-    local result, i, g, ok, j, sel, range, nid;
-
-    if not IsBound( inforec.number ) then
-        inforec := NUMBER_SMALL_GROUPS_FUNCS[ inforec.func ]( size, inforec);
-    fi;
-
-    # narrow down the candidates using properties which can be decided from
-    # the position of a group in the library
-    sel   := SMALL_GROUPS_PROPERTY_IDS( size, inforec, funcs, vals );
-    funcs := sel.funcs;
-    vals  := sel.vals;
-
-    if idList = fail then
-        range := SMALL_IDS_EXPAND( sel.ids );
-    else
-        range := Filtered( idList, x -> SMALL_IDS_MEMBER( sel.ids, x ) );
-    fi;
-
-    # if nothing is left to be checked, the groups need not be constructed
-    if funcs = [ ] and all and id then
-        return List( range, x -> [ size, x ] );
-    fi;
-
-    if funcs <> [ ] and idList = fail then
-        Info( InfoWarning, 2, "`SelectSmallGroups' checks ", Length( range ),
-                            " grps of size ", size, " with trivial methods");
-    fi;
-
-    result := [ ];
-    for i in range do
-        nid:=i;
-        if not SMALL_GROUPS_OLD_ORDER then
-            if size = 3^7 then
-                nid := SMALLGP_PERM3(i);
-            elif size = 5^7 then
-                nid := SMALLGP_PERM5(i);
-            elif size = 7^7 then
-                nid := SMALLGP_PERM7(i);
-            elif size = 11^7 then
-                nid := SMALLGP_PERM11(i);
-            fi;
-        fi;
-
-        g := SMALL_GROUP_FUNCS[ inforec.func ]( size, nid, inforec );
-        SetIdGroup( g, [ size, i ] );
-        ok := true;
-        for j in [ 1 .. Length( funcs ) ] do
-            ok := ok and funcs[ j ]( g ) in vals[ j ];
-        od;
-        if all and id and ok then
-            Add( result, [ size, i ] );
-        elif all and ok then
-            Add( result, g );
-        elif ok then          
-            return g;                                           
-        fi;
-    od;                                                                     
-
-    if all then
-        return result;
-    else
-        return fail;
-    fi;
-end;
+##
+#F SELECT_SMALL_GROUPS_FUNCS[ 11 ]
+##
+SELECT_SMALL_GROUPS_FUNCS[ 11 ] := SMALL_GROUPS_SELECT_GENERIC;
 
 #############################################################################
 ##

--- a/small4/smlgp4.g
+++ b/small4/smlgp4.g
@@ -221,7 +221,7 @@ end;
 ##
 #F SELECT_SMALL_GROUPS_FUNCS[ 17 ]
 ##                                                                              
-SELECT_SMALL_GROUPS_FUNCS[ 17 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
+SELECT_SMALL_GROUPS_FUNCS[ 17 ] := SMALL_GROUPS_SELECT_GENERIC;
 
 #############################################################################
 ##

--- a/small6/smlgp6.g
+++ b/small6/smlgp6.g
@@ -22,6 +22,8 @@ SMALL_AVAILABLE_FUNCS[ 6 ] := function( size )
     return fail;
 end;
 
+DeclareGlobalName( "SMALL_GROUP_1152_1920_FROM_CODE" );
+
 #############################################################################
 ##
 #F SMALL_GROUP_FUNCS[ 12 ]( size, i, inforec )
@@ -35,15 +37,15 @@ SMALL_GROUP_FUNCS[ 12 ] := function( size, i, inforec )
 
     if size = 1152 then
         if i <= 2328 then
-            return SMALL_GROUP_FUNCS[ 13 ]( 32769, 1152, i );
+            return SMALL_GROUP_1152_1920_FROM_CODE( 32769, 1152, i );
         elif i <= 4656 then
-            return SMALL_GROUP_FUNCS[ 13 ]( 0, 1152, i - 2328 );
+            return SMALL_GROUP_1152_1920_FROM_CODE( 0, 1152, i - 2328 );
         else
              i := i - 4656;
         fi;
     elif size = 1920 then
         if i <= 2328 then
-            return SMALL_GROUP_FUNCS[ 13 ]( 0, 1920, i );
+            return SMALL_GROUP_1152_1920_FROM_CODE( 0, 1920, i );
         else
              i := i - 2328;
         fi;
@@ -79,7 +81,7 @@ SMALL_GROUP_FUNCS[ 12 ] := function( size, i, inforec )
             sid := sid + 1;
         od;
 
-        return SMALL_GROUP_FUNCS[ 13 ]( 
+        return SMALL_GROUP_1152_1920_FROM_CODE( 
                  SMALL_GROUP_LIB[ size ].2nil.codes[
                    SMALL_GROUP_LIB[ size ].2nil.codelist[                    
                      SMALL_GROUP_LIB[ size ].2nil.styps[ sid ] ][ i ] ],
@@ -106,13 +108,13 @@ end;
 
 #############################################################################
 ##
-#F SMALL_GROUP_FUNCS[ 13 ]( code, size, sid )
+#F SMALL_GROUP_1152_1920_FROM_CODE( code, size, sid )
 ##
-## similar function to 'RelatorsCode' specialized for groups of size 1152
-## and 1920 with normal (3,5)-Hall-subgroup, for which the relators of the
-## 2-sylow-subgroup are not stored with the group.
+## like 'RelatorsCode', for the groups of order 1152 and 1920 with a normal
+## (3,5)-Hall-subgroup, whose Sylow 2-subgroup relators are not stored with
+## the group but fetched by sid from the groups of order 128
 ##
-SMALL_GROUP_FUNCS[ 13 ] := function( code, size, sid )
+SMALL_GROUP_1152_1920_FROM_CODE := function( code, size, sid )
     local F, gens, i, j, z, z2, rels, trels, rr, g, t, n, uc, indices, ll;
 
     # create free group

--- a/small7/smlgp7.g
+++ b/small7/smlgp7.g
@@ -157,7 +157,7 @@ end;
 ##                          
 #F SELECT_SMALL_GROUPS_FUNCS[ 18 ]( funcs, vals, inforec, all, id )
 ##                  
-SELECT_SMALL_GROUPS_FUNCS[ 18 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
+SELECT_SMALL_GROUPS_FUNCS[ 18 ] := SMALL_GROUPS_SELECT_GENERIC;
 
 #############################################################################
 ##

--- a/small8/smlgp8.g
+++ b/small8/smlgp8.g
@@ -310,7 +310,7 @@ end;
 ##                          
 #F SELECT_SMALL_GROUPS_FUNCS[ 14 ]( funcs, vals, inforec, all, id, idList )
 ##                  
-SELECT_SMALL_GROUPS_FUNCS[ 14 ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
+SELECT_SMALL_GROUPS_FUNCS[ 14 ] := SMALL_GROUPS_SELECT_GENERIC;
 
 #############################################################################
 ##

--- a/small9/smlgp9.g
+++ b/small9/smlgp9.g
@@ -500,6 +500,9 @@ SMALL_GROUP_FUNCS[ 20 ] := function( size, i, inforec )
     return g;
 end;
 
+DeclareGlobalName( "SMALL_GROUP_P6_NUMBER" );
+DeclareGlobalName( "SMALL_GROUP_P6_EXPONENT" );
+
 #############################################################################
 ##
 #F SMALL_GROUP_FUNCS[ 21 ]( size, i, inforec )
@@ -573,7 +576,7 @@ SMALL_GROUP_FUNCS[ 21 ] := function( size, i, inforec )
                     n := QuoInt( n, 7 );
                     j2 := n mod 50;
                     n := QuoInt( n, 50 );
-                    ri := ri * g^SMALL_GROUP_FUNCS[23]( j2, inforec, fail );
+                    ri := ri * g^SMALL_GROUP_P6_EXPONENT( j2, inforec, fail );
                 od;
                 famRels[ ind ] := famRels[ ind ] / ri;
             od;
@@ -584,7 +587,7 @@ SMALL_GROUP_FUNCS[ 21 ] := function( size, i, inforec )
                 n := QuoInt( n, 9 );
                 c2 := n mod 22;
                 n := QuoInt( n, 22 );
-                mem := rec( num := SMALL_GROUP_FUNCS[ 22 ]( c1, c2, p ),
+                mem := rec( num := SMALL_GROUP_P6_NUMBER( c1, c2, p ),
                             rels := [] );
                 if mem.num > 0 then
                     while n > 0 do
@@ -624,7 +627,7 @@ SMALL_GROUP_FUNCS[ 21 ] := function( size, i, inforec )
     for rel in inforec.groups[ phi ][ j ].famMems[ k ].rels do
         ri := One( F );
         for m in rel.exli do
-            ri := ri * F.(m[1])^SMALL_GROUP_FUNCS[23]( m[2], inforec, i );
+            ri := ri * F.(m[1])^SMALL_GROUP_P6_EXPONENT( m[2], inforec, i );
         od;
         grpRels[ rel.ind ] := grpRels[ rel.ind ] / ri;
     od;
@@ -641,10 +644,12 @@ end;
 
 #############################################################################
 ##
-#F SMALL_GROUP_FUNCS[ 22 ]( c1, c2, p )
+#F SMALL_GROUP_P6_NUMBER( c1, c2, p )
 ##
-## 
-SMALL_GROUP_FUNCS[ 22 ] := function( c1, c2, p )
+## how many groups the parametrised entry ( c1, c2 ) stands for at p; 0 if
+## the condition c1 puts on p fails
+
+SMALL_GROUP_P6_NUMBER := function( c1, c2, p )
 
     if c1 = 0 or
        c1 = 1 and p mod 3 = 1 or
@@ -697,10 +702,11 @@ end;
 
 #############################################################################
 ##
-#F SMALL_GROUP_FUNCS[ 23 ]( j2, inforec )
+#F SMALL_GROUP_P6_EXPONENT( j2, inforec, ii )
 ##
-## 
-SMALL_GROUP_FUNCS[ 23 ] := function( j2, inforec, ii )
+## the exponent the code j2 stands for at p
+
+SMALL_GROUP_P6_EXPONENT := function( j2, inforec, ii )
     local p, pr, nqr, nqrm, squares,
           cart, f, gg, k, r, s, t, x, y, z;
 

--- a/tst/construct.tst
+++ b/tst/construct.tst
@@ -1,0 +1,26 @@
+#
+# Constructing groups from the paths the other test files never take
+#
+gap> START_TEST("construct.tst");
+
+# the 4912 groups of order 768 without a normal Sylow subgroup are stored in
+# four files; take one group from each, and identify it again
+gap> ids := [1085324, 1086574, 1087824, 1089074];;
+gap> List(ids, i -> Size(SmallGroup(768, i)));
+[ 768, 768, 768, 768 ]
+gap> List(ids, i -> IdGroup(SmallGroup(768, i))) = List(ids, i -> [768, i]);
+true
+
+# p^7 for the primes other than 5, which tst/ordering.tst builds
+gap> List([3^7, 7^7, 11^7], NrSmallGroups);
+[ 9310, 113147, 750735 ]
+gap> ForAll([3^7, 7^7, 11^7], n ->
+>      ForAll([1, 2, NrSmallGroups(n)], i -> Size(SmallGroup(n, i)) = n));
+true
+gap> List([3^7, 7^7, 11^7], n -> RankPGroup(SmallGroup(n, NrSmallGroups(n))));
+[ 7, 7, 7 ]
+gap> List([3^7, 7^7, 11^7], n -> RankPGroup(SmallGroup(n, 1)));
+[ 1, 1, 1 ]
+
+#
+gap> STOP_TEST("construct.tst");

--- a/tst/small.tst
+++ b/tst/small.tst
@@ -45,10 +45,13 @@ gap> Filtered([1..4000], i -> NumberSmallGroupsAvailable(i) <> SmallGroupsAvaila
 ################################################################################
 gap> Length(SMALL_GROUP_FUNCS) >= 26;
 true
-gap> Number(SMALL_GROUP_FUNCS) >= 24;
+gap> Number(SMALL_GROUP_FUNCS) >= 21;
 true
+
+# 13, 22 and 23 held helpers that were never dispatched to; 15 and 16 are
+# used by ID_GROUP_FUNCS only
 gap> Filtered([1 .. 26], i -> not IsBound(SMALL_GROUP_FUNCS[i]));
-[ 15, 16 ]
+[ 13, 15, 16, 22, 23 ]
 gap> Length(CODE_SMALL_GROUP_FUNCS) >= 10;
 true
 gap> Number(CODE_SMALL_GROUP_FUNCS) >= 3;


### PR DESCRIPTION
First step towards #67. No behaviour change; every array entry stays, so
sglppow and SOTGrps keep working untouched.

Extending the library currently means filling six arrays by number, ending
with the line both extension packages contain:

```gap
SELECT_SMALL_GROUPS_FUNCS[ SOTGRPS_POS ] := SELECT_SMALL_GROUPS_FUNCS[ 11 ];
```

Nothing says what `11` is. A survey found the tangle is smaller than the file
layout suggests — exactly three functions are used across layers, and
everything else is within one layer:

| slot | name |
|---|---|
| `SELECT_SMALL_GROUPS_FUNCS[11]` | `SMALL_GROUPS_SELECT_GENERIC` |
| `ID_GROUP_FUNCS[8]` | `ID_GROUP_BY_TREE` |
| `CODE_SMALL_GROUP_FUNCS[8]` | `CODE_SMALL_GROUP_FROM_LIB` |

Only the generic selection moves file, from `small3` to `gap/small.gi`, since
it belongs to no layer and that file is read first.

`SMALL_GROUP_FUNCS` also held three helpers taking arguments other than
`( size, i, inforec )`, which no `inforec` ever dispatched to — they were
parked in the dispatch table. They become `SMALL_GROUP_1152_1920_FROM_CODE`,
`SMALL_GROUP_P6_NUMBER` and `SMALL_GROUP_P6_EXPONENT`, freeing slots 13, 22
and 23 and ending the collision between `SMALL_GROUP_FUNCS[13]` and the
unrelated `ID_GROUP_FUNCS[13]`. Each gets a `DeclareGlobalName` where it is
first used rather than moving, to keep the diff reviewable.

`tst/small.tst` asserts which slots are occupied, so its expectation changes
accordingly.

### Verified

- smallgrp test suite, 0 failures in 11 files
- `tst/verify-indices.g`, 0 failures
- manual builds without warnings
- **sglppow**, 0 failures in 3 files, unmodified
- **SOTGrps**, 0 failures in 5 files, unmodified

The last two are the point: both reference `SELECT_SMALL_GROUPS_FUNCS[11]` by
number, and exercise the compatibility aliases against released code.